### PR TITLE
Suppport salt-extension-copier 0.4.0+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "copier>=9.1",
     "copier-templates-extensions",
 ]
-version = "1.0.0"
+version = "1.1.0"
 
 [project.readme]
 file = "README.md"

--- a/src/saltext_migrate/cli.py
+++ b/src/saltext_migrate/cli.py
@@ -14,7 +14,10 @@ def main():
     )
     parser.add_argument(
         "saltext_name",
-        help="The name of the Salt extension to create.",
+        help=(
+            "The name of the Salt extension to create (without `saltext` prefix!)."
+            " Example: vault"
+        ),
     )
     parser.add_argument(
         "-m",

--- a/src/saltext_migrate/rewrite.py
+++ b/src/saltext_migrate/rewrite.py
@@ -152,7 +152,7 @@ class DunderParser(ast.NodeTransformer):  # pylint: disable=missing-class-docstr
 
 
 def _get_salt_code_root():
-    return (next(Path("venv/lib").glob("python3.*")) / "site-packages").resolve()
+    return (next(Path(".venv/lib").glob("python3.*")) / "site-packages").resolve()
 
 
 def _defaultdict_factory():
@@ -226,7 +226,7 @@ class UtilsMigrator:
 
     def __post_init__(self):
         self._salt_base_path = (
-            next((self.saltext_path / "venv" / "lib").glob("python3.*"))
+            next((self.saltext_path / ".venv" / "lib").glob("python3.*"))
             / "site-packages"
         ).resolve()
         self._saltext_base_path = (self.saltext_path / "src").resolve()


### PR DESCRIPTION
Ensures the new Copier template automation is skipped, the venv is created in `.venv` and Pylint is relaxed for the legacy code.